### PR TITLE
Modified to allow copying proof as a JSON string.

### DIFF
--- a/android/v2/app/src/main/java/org/ethtokyo/hackathon/anastasia/ui/proofcompleted/ProofCompletedFragment.kt
+++ b/android/v2/app/src/main/java/org/ethtokyo/hackathon/anastasia/ui/proofcompleted/ProofCompletedFragment.kt
@@ -5,10 +5,17 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import org.json.JSONArray
+import org.json.JSONObject
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -51,8 +58,27 @@ class ProofCompletedFragment : Fragment() {
 
         setupUI(proofsResult.proofs, proofsText)
         setupObservers()
+        setupMenu()
 
         return binding.root
+    }
+
+    private fun setupMenu() {
+        requireActivity().addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.proof_completed_menu, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    R.id.action_copy_proofs_json -> {
+                        copyProofsAsJson()
+                        true
+                    }
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
     private fun setupUI(proofResults: Array<ProofResult>, proofsText: String) {
@@ -113,6 +139,24 @@ class ProofCompletedFragment : Fragment() {
         val clip = ClipData.newPlainText("Proof Data", text)
         clipboard.setPrimaryClip(clip)
         Toast.makeText(requireContext(), "Proof data copied to clipboard", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun copyProofsAsJson() {
+        val proofsResult = args.proofsResult
+        val jsonArray = JSONArray()
+
+        proofsResult.proofs.forEach { proofResult ->
+            val jsonObject = JSONObject()
+            jsonObject.put("proof", proofResult.proof)
+            jsonArray.put(jsonObject)
+        }
+
+        val jsonString = jsonArray.toString(2) // インデント2でフォーマット
+
+        val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("Proofs JSON", jsonString)
+        clipboard.setPrimaryClip(clip)
+        Toast.makeText(requireContext(), "Proofs JSON copied to clipboard", Toast.LENGTH_SHORT).show()
     }
 
     private fun setupObservers() {

--- a/android/v2/app/src/main/res/menu/proof_completed_menu.xml
+++ b/android/v2/app/src/main/res/menu/proof_completed_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_copy_proofs_json"
+        android:title="Copy proofs as JSON"
+        app:showAsAction="never" />
+</menu>

--- a/android/v2/app/src/main/res/navigation/mobile_navigation.xml
+++ b/android/v2/app/src/main/res/navigation/mobile_navigation.xml
@@ -80,7 +80,7 @@
     <fragment
         android:id="@+id/proofCompletedFragment"
         android:name="org.ethtokyo.hackathon.anastasia.ui.proofcompleted.ProofCompletedFragment"
-        android:label="Proof generation completed"
+        android:label="Generation finished"
         tools:layout="@layout/fragment_proof_completed">
         <argument
             android:name="proofsResult"


### PR DESCRIPTION
A menu has been added to the top-right corner of the Proof generation completion screen, allowing the Proof to be copied to the clipboard by tapping it.


<img width="342" height="720" alt="スクリーンショット 2025-10-04 22 05 55" src="https://github.com/user-attachments/assets/f8732d95-6944-4c3c-9858-b998f8172ac1" />

<img width="342" height="720" alt="スクリーンショット 2025-10-04 22 05 58" src="https://github.com/user-attachments/assets/0f7e14fa-37d1-4b3f-8346-7966e2e56b93" />

The structure of the JSON string that is copied is as follows:

```
[
    {"proof": "<proof string>"},
    {"proof": "<proof string>"}
]
```